### PR TITLE
Decapitalize talent names for lancer-data consistency

### DIFF
--- a/talents.json
+++ b/talents.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "t_demolitionist",
-    "name": "DEMOLITIONIST",
+    "name": "Demolitionist",
     "description": "Explosives and warfare go together like alcohol and bad decisions. The power of a bomb in the palm of your hand is a great equalizer, and a well-placed satchel charge or two has brought even the mightiest of fortifications tumbling down. Forget bullets with names etched on them, the packages you deliver go out addressed “To Whom It May Concern,” and you’ve got plenty to go around.",
     "ranks": [
       {
@@ -20,7 +20,7 @@
   },
   {
     "id": "t_sysop",
-    "name": "SYSOP",
+    "name": "Sysop",
     "terse": "",
     "description": "Modern systemic warfare is a filthy mess of code-worms, logic bombs, and adaptive viruses, to say nothing of all the physical detritus that litters the battlefield, and you’re the one responsible for keeping things clean. System operator or system optimizer, formatting software barriers or tuning servos, your command of diagnostic programs and deep-level hardware overrides gives you all the tools you need to push your squad’s limits beyond manufacturer spec with orderly, surgical precision.",
     "ranks": [


### PR DESCRIPTION
# Description
De-capitalizes the Talent names to be consistent with the current capitalization convention in Lancer-Data.